### PR TITLE
VS003.5 — freeform table UX stabilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ The product goal is one continuous tool for world building, lore, scene navigati
 - token persistence/recovery through SurrealDB;
 - provisional claimed-player ownership semantics without pretending client names are authentication.
 
+**Vertical Slice 003.5** stabilizes the table UX before vision/combat work:
+
+- freeform Live widgets with overlap, free resize and z-order;
+- optional Snap Grid mode instead of mandatory compaction;
+- the same freeform primitive for floating Director tools;
+- optimistic token movement held until authoritative confirmation, removing accepted-move rubber-band;
+- contextual map popovers for scene/lore hotspots.
+
 Walls/doors, fog/vision, initiative/targeting, travel rules, hex-map generation, auth/roles, secret-lore authorization and the Content/Character/Action/Effect engines remain intentionally separate milestones.
 
 ## Development architecture
@@ -48,6 +56,7 @@ Only the gateway is published to the homelab Tailscale address. SurrealDB, Colys
 - `docs/VERTICAL-SLICE-001.md` — live-runtime foundation evidence
 - `docs/VERTICAL-SLICE-002.md` — Scene Atlas foundation evidence
 - `docs/VERTICAL-SLICE-003.md` — authoritative token foundation evidence
+- `docs/VERTICAL-SLICE-003-5.md` — freeform workspace and interaction stabilization evidence
 - `docs/LEGACY-REVIEW.md` — what v0.0.4 may and may not influence
 - `docs/adr/` — architecture decision records
 - `docs/RUNBOOK.md` — operator/developer commands

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,7 +15,7 @@ export function App() {
           <span className="brand-mark">UTT</span>
           <div>
             <strong>Under The Table</strong>
-            <span>Vertical Slice 003 · Tokens</span>
+            <span>Vertical Slice 003.5 · Table UX</span>
           </div>
         </div>
 
@@ -29,8 +29,8 @@ export function App() {
 
         <div className="topbar-actions">
           <div className="view-switch" aria-label="Workspace view">
-            <button className={view === "atlas" ? "active" : ""} type="button" onClick={() => setView("atlas")}>Atlas</button>
-            <button className={view === "hud" ? "active" : ""} type="button" onClick={() => setView("hud")}>Table HUD</button>
+            <button className={view === "atlas" ? "active" : ""} type="button" onClick={() => setView("atlas")}>Director</button>
+            <button className={view === "hud" ? "active" : ""} type="button" onClick={() => setView("hud")}>Live</button>
           </div>
           <span className="environment-badge">TAILSCALE DEV</span>
           {view === "hud" ? <button className="ghost-button" type="button" onClick={() => setLayoutResetToken((value) => value + 1)}>Reset HUD</button> : null}
@@ -68,8 +68,8 @@ export function App() {
       )}
 
       <footer className="footer-note">
-        <span>{view === "atlas" ? "Scene Atlas foundation" : "Live HUD foundation"}</span>
-        <span>{view === "atlas" ? "Pan · zoom · link · present" : "Drag from widget headers · Resize from edges"}</span>
+        <span>{view === "atlas" ? "Director workspace" : "Live workspace"}</span>
+        <span>{view === "atlas" ? "Browse privately · present · floating DM tools" : "Freeform or snap-grid widgets · overlap allowed"}</span>
       </footer>
     </div>
   );

--- a/apps/web/src/components/AtlasWorkspace.tsx
+++ b/apps/web/src/components/AtlasWorkspace.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import type { AtlasSceneDto, AtlasTokenDto } from "@utt/protocol";
 import { useAtlas, type CreateHotspotDraft, type CreateSceneDraft } from "../atlas.js";
+import { DirectorOverlay } from "./DirectorOverlay.js";
 import { SceneCanvas } from "./SceneCanvas.js";
 
 interface AtlasWorkspaceProps {
@@ -164,6 +165,8 @@ export function AtlasWorkspace({ activeSceneId, liveTokens, clientName, tokenRev
   const [pendingTokenPoint, setPendingTokenPoint] = useState<{ x: number; y: number } | null>(null);
   const [createKind, setCreateKind] = useState<AtlasSceneDto["kind"] | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [showDirectorWidgets, setShowDirectorWidgets] = useState(() => window.matchMedia("(min-width: 900px)").matches);
+  const [directorResetToken, setDirectorResetToken] = useState(0);
 
   const scenes = atlas.data?.scenes ?? [];
   useEffect(() => {
@@ -238,16 +241,36 @@ export function AtlasWorkspace({ activeSceneId, liveTokens, clientName, tokenRev
       </aside>
 
       <div className="scene-column">
-        <div className="scene-context-bar"><div><span>{scene.id === activeSceneId ? "Live scene" : "Browsing privately"}</span><strong>{scene.name}</strong></div><div className="context-actions">{!followTable && activeScene ? <button className="ghost-button" type="button" onClick={() => { setFollowTable(true); browse(activeScene.id); }}>Follow table</button> : null}<button className="game-button primary" type="button" disabled={scene.id === activeSceneId} onClick={() => { onPresentScene(scene.id); setFollowTable(true); }}>{scene.id === activeSceneId ? "On table" : "Present to table"}</button></div></div>
+        <div className="scene-context-bar"><div><span>{scene.id === activeSceneId ? "Live scene" : "Browsing privately"}</span><strong>{scene.name}</strong></div><div className="context-actions">
+          <button className={`ghost-button ${showDirectorWidgets ? "active" : ""}`} type="button" onClick={() => setShowDirectorWidgets((value) => !value)}>{showDirectorWidgets ? "Hide DM widgets" : "DM widgets"}</button>
+          {showDirectorWidgets ? <button className="ghost-button" type="button" onClick={() => setDirectorResetToken((value) => value + 1)}>Reset DM layout</button> : null}
+          {!followTable && activeScene ? <button className="ghost-button" type="button" onClick={() => { setFollowTable(true); browse(activeScene.id); }}>Follow table</button> : null}
+          <button className="game-button primary" type="button" disabled={scene.id === activeSceneId} onClick={() => { onPresentScene(scene.id); setFollowTable(true); }}>{scene.id === activeSceneId ? "On table" : "Present to table"}</button>
+        </div></div>
         <SceneCanvas
           scene={scene} hotspots={hotspots} tokens={sceneTokens} clientName={clientName}
-          selectedHotspotId={selectedHotspotId} addPinMode={addPinMode} addTokenMode={addTokenMode}
+          selectedHotspotId={selectedHotspotId}
+          selectedHotspotLore={hotspotEntity?.summary ?? null}
+          selectedHotspotLinkedSceneName={linkedScene?.name ?? null}
+          addPinMode={addPinMode} addTokenMode={addTokenMode}
           onToggleAddPin={() => { setAddTokenMode(false); setAddPinMode((value) => !value); }}
           onToggleAddToken={() => { setAddPinMode(false); setAddTokenMode((value) => !value); }}
           onCanvasPoint={(point) => { setPendingPoint(point); setAddPinMode(false); }}
           onTokenPoint={(point) => { setPendingTokenPoint(point); setAddTokenMode(false); }}
-          onHotspotSelect={(hotspot) => setSelectedHotspotId(hotspot.id)} onTokenMove={onMoveToken}
+          onHotspotSelect={(hotspot) => setSelectedHotspotId(hotspot.id)}
+          onHotspotEnter={(hotspot) => { const target = scenes.find((item) => item.id === hotspot.linkedSceneId); if (target) browse(target.id); }}
+          onTokenMove={onMoveToken}
         />
+        {showDirectorWidgets ? (
+          <DirectorOverlay
+            scene={scene}
+            activeScene={activeScene}
+            tokens={sceneTokens}
+            resetToken={directorResetToken}
+            onPresent={() => { onPresentScene(scene.id); setFollowTable(true); }}
+            onFollowTable={() => { if (activeScene) { setFollowTable(true); browse(activeScene.id); } }}
+          />
+        ) : null}
       </div>
 
       <aside className="scene-inspector">

--- a/apps/web/src/components/DirectorOverlay.tsx
+++ b/apps/web/src/components/DirectorOverlay.tsx
@@ -1,0 +1,58 @@
+import type { AtlasSceneDto, AtlasTokenDto } from "@utt/protocol";
+import { FreeformSurface, type FreeformItem } from "./FreeformSurface.js";
+import { WidgetFrame } from "./WidgetFrame.js";
+
+interface DirectorOverlayProps {
+  scene: AtlasSceneDto;
+  activeScene: AtlasSceneDto | null;
+  tokens: AtlasTokenDto[];
+  resetToken: number;
+  onPresent: () => void;
+  onFollowTable: () => void;
+}
+
+export function DirectorOverlay({
+  scene, activeScene, tokens, resetToken, onPresent, onFollowTable
+}: DirectorOverlayProps) {
+  const items: FreeformItem[] = [
+    {
+      id: "director-scene",
+      initial: { x: 18, y: 76, width: 270, height: 210, z: 2 },
+      minWidth: 230,
+      minHeight: 170,
+      node: (
+        <WidgetFrame eyebrow="Director" title={scene.name} meta={scene.id === activeScene?.id ? "ON TABLE" : "PRIVATE"}>
+          <div className="director-widget-copy">
+            <span>{scene.grid.visible ? `${scene.grid.kind} grid · ${scene.grid.size}` : "No grid"}</span>
+            <p>{scene.id === activeScene?.id ? "This is the scene players are currently following." : "You are browsing this scene privately."}</p>
+          </div>
+          <div className="stack-actions">
+            {scene.id !== activeScene?.id ? <button className="game-button primary" type="button" onClick={onPresent}>Present to table</button> : null}
+            {scene.id !== activeScene?.id && activeScene ? <button className="ghost-button" type="button" onClick={onFollowTable}>Follow {activeScene.name}</button> : null}
+          </div>
+        </WidgetFrame>
+      )
+    },
+    {
+      id: "director-tokens",
+      initial: { x: 18, y: 304, width: 270, height: 260, z: 1 },
+      minWidth: 230,
+      minHeight: 180,
+      node: (
+        <WidgetFrame eyebrow="Scene" title="Token roster" meta={`${tokens.length} token${tokens.length === 1 ? "" : "s"}`}>
+          <div className="token-roster director-token-roster">
+            {tokens.map((token) => (
+              <span key={token.id} className={`token-roster-item ${token.kind}`}>
+                <b>{token.label}</b>
+                <small>{token.controllerName ? token.controllerName : token.kind}</small>
+              </span>
+            ))}
+            {tokens.length === 0 ? <p className="empty-state">No tokens on this scene.</p> : null}
+          </div>
+        </WidgetFrame>
+      )
+    },
+  ];
+
+  return <FreeformSurface items={items} storageKey="utt.director.freeform.v1" resetToken={resetToken} overlay className="director-freeform" />;
+}

--- a/apps/web/src/components/FreeformSurface.tsx
+++ b/apps/web/src/components/FreeformSurface.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
+
+export interface FreeformPlacement {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  z: number;
+}
+
+export interface FreeformItem {
+  id: string;
+  initial: FreeformPlacement;
+  minWidth?: number;
+  minHeight?: number;
+  node: ReactNode;
+}
+
+interface FreeformSurfaceProps {
+  items: FreeformItem[];
+  storageKey: string;
+  resetToken?: number;
+  snap?: number;
+  overlay?: boolean;
+  className?: string;
+}
+
+type PlacementMap = Record<string, FreeformPlacement>;
+type Gesture = {
+  id: string;
+  pointerId: number;
+  mode: "move" | "resize";
+  clientX: number;
+  clientY: number;
+  start: FreeformPlacement;
+};
+
+const roundTo = (value: number, snap: number) => snap > 0 ? Math.round(value / snap) * snap : value;
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+function defaults(items: FreeformItem[]): PlacementMap {
+  return Object.fromEntries(items.map((item) => [item.id, { ...item.initial }]));
+}
+
+function load(items: FreeformItem[], storageKey: string): PlacementMap {
+  const fallback = defaults(items);
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw) as Record<string, Partial<FreeformPlacement>>;
+    for (const item of items) {
+      const saved = parsed[item.id];
+      if (!saved) continue;
+      const values = [saved.x, saved.y, saved.width, saved.height, saved.z];
+      if (values.every((value) => typeof value === "number" && Number.isFinite(value))) {
+        fallback[item.id] = saved as FreeformPlacement;
+      }
+    }
+  } catch {
+    return fallback;
+  }
+  return fallback;
+}
+
+export function FreeformSurface({ items, storageKey, resetToken = 0, snap = 0, overlay = false, className = "" }: FreeformSurfaceProps) {
+  const surfaceRef = useRef<HTMLDivElement>(null);
+  const gestureRef = useRef<Gesture | null>(null);
+  const [placements, setPlacements] = useState<PlacementMap>(() => load(items, storageKey));
+  const itemsById = useMemo(() => new Map(items.map((item) => [item.id, item])), [items]);
+
+  useEffect(() => {
+    setPlacements((current) => {
+      const next = { ...current };
+      let changed = false;
+      for (const item of items) {
+        if (!next[item.id]) {
+          next[item.id] = { ...item.initial };
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+  }, [items]);
+
+  useEffect(() => {
+    if (resetToken <= 0) return;
+    const next = defaults(items);
+    setPlacements(next);
+    window.localStorage.removeItem(storageKey);
+  }, [items, resetToken, storageKey]);
+
+  useEffect(() => {
+    window.localStorage.setItem(storageKey, JSON.stringify(placements));
+  }, [placements, storageKey]);
+
+  const bringToFront = (id: string) => {
+    setPlacements((current) => {
+      const placement = current[id];
+      if (!placement) return current;
+      const top = Math.max(0, ...Object.values(current).map((value) => value.z));
+      if (placement.z === top) return current;
+      return { ...current, [id]: { ...placement, z: top + 1 } };
+    });
+  };
+
+  const beginMove = (event: ReactPointerEvent<HTMLDivElement>, id: string) => {
+    if (event.button !== 0) return;
+    const target = event.target as HTMLElement;
+    if (!target.closest(".widget-handle") || target.closest("button, input, select, textarea, a")) return;
+    const start = placements[id];
+    if (!start) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    bringToFront(id);
+    gestureRef.current = { id, pointerId: event.pointerId, mode: "move", clientX: event.clientX, clientY: event.clientY, start };
+    event.preventDefault();
+  };
+
+  const beginResize = (event: ReactPointerEvent<HTMLButtonElement>, id: string) => {
+    if (event.button !== 0) return;
+    const start = placements[id];
+    if (!start) return;
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    bringToFront(id);
+    gestureRef.current = { id, pointerId: event.pointerId, mode: "resize", clientX: event.clientX, clientY: event.clientY, start };
+  };
+
+  const updateGesture = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const gesture = gestureRef.current;
+    if (!gesture || gesture.pointerId !== event.pointerId) return;
+    const item = itemsById.get(gesture.id);
+    const surface = surfaceRef.current;
+    if (!item || !surface) return;
+    const dx = event.clientX - gesture.clientX;
+    const dy = event.clientY - gesture.clientY;
+    const bounds = surface.getBoundingClientRect();
+    const minWidth = item.minWidth ?? 220;
+    const minHeight = item.minHeight ?? 150;
+
+    setPlacements((current) => {
+      const active = current[gesture.id];
+      if (!active) return current;
+      if (gesture.mode === "move") {
+        const maxX = Math.max(0, bounds.width - gesture.start.width);
+        const maxY = Math.max(0, bounds.height - gesture.start.height);
+        return {
+          ...current,
+          [gesture.id]: {
+            ...active,
+            x: roundTo(clamp(gesture.start.x + dx, 0, maxX), snap),
+            y: roundTo(clamp(gesture.start.y + dy, 0, maxY), snap)
+          }
+        };
+      }
+      const maxWidth = Math.max(minWidth, bounds.width - gesture.start.x);
+      const maxHeight = Math.max(minHeight, bounds.height - gesture.start.y);
+      return {
+        ...current,
+        [gesture.id]: {
+          ...active,
+          width: roundTo(clamp(gesture.start.width + dx, minWidth, maxWidth), snap),
+          height: roundTo(clamp(gesture.start.height + dy, minHeight, maxHeight), snap)
+        }
+      };
+    });
+  };
+
+  const endGesture = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (gestureRef.current?.pointerId === event.pointerId) gestureRef.current = null;
+  };
+
+  return (
+    <div
+      ref={surfaceRef}
+      className={`freeform-surface ${overlay ? "overlay" : ""} ${className}`.trim()}
+      onPointerMove={updateGesture}
+      onPointerUp={endGesture}
+      onPointerCancel={endGesture}
+    >
+      {items.map((item) => {
+        const placement = placements[item.id] ?? item.initial;
+        return (
+          <div
+            key={item.id}
+            data-freeform-widget={item.id}
+            className="freeform-item"
+            style={{ left: placement.x, top: placement.y, width: placement.width, height: placement.height, zIndex: placement.z }}
+            onPointerDown={(event) => beginMove(event, item.id)}
+          >
+            {item.node}
+            <button
+              type="button"
+              className="freeform-resize-handle"
+              aria-label={`Resize ${item.id} widget`}
+              onPointerDown={(event) => beginResize(event, item.id)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/HudGrid.tsx
+++ b/apps/web/src/components/HudGrid.tsx
@@ -1,29 +1,33 @@
-import { useEffect, useState } from "react";
-import ReactGridLayout, {
-  useContainerWidth,
-  verticalCompactor,
-  type Layout
-} from "react-grid-layout";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import ReactGridLayout, { useContainerWidth, verticalCompactor, type Layout } from "react-grid-layout";
 import type { LiveViewState } from "../live-room.js";
+import { FreeformSurface, type FreeformItem } from "./FreeformSurface.js";
 import { WidgetFrame } from "./WidgetFrame.js";
 
-const LAYOUT_KEY = "utt.vs001.layout";
+const GRID_LAYOUT_KEY = "utt.vs001.layout";
+const MODE_KEY = "utt.hud.layout-mode.v1";
 
-const DEFAULT_LAYOUT: Layout = [
+const DEFAULT_GRID_LAYOUT: Layout = [
   { i: "character", x: 0, y: 0, w: 4, h: 7, minW: 3, minH: 6 },
   { i: "dice", x: 4, y: 0, w: 4, h: 7, minW: 3, minH: 6 },
   { i: "events", x: 8, y: 0, w: 4, h: 11, minW: 3, minH: 7 }
 ];
 
-function loadLayout(): Layout {
+type HudLayoutMode = "freeform" | "grid";
+
+function loadGridLayout(): Layout {
   try {
-    const raw = window.localStorage.getItem(LAYOUT_KEY);
-    if (!raw) return DEFAULT_LAYOUT;
+    const raw = window.localStorage.getItem(GRID_LAYOUT_KEY);
+    if (!raw) return DEFAULT_GRID_LAYOUT;
     const parsed: unknown = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as Layout) : DEFAULT_LAYOUT;
+    return Array.isArray(parsed) ? (parsed as Layout) : DEFAULT_GRID_LAYOUT;
   } catch {
-    return DEFAULT_LAYOUT;
+    return DEFAULT_GRID_LAYOUT;
   }
+}
+
+function loadMode(): HudLayoutMode {
+  return window.localStorage.getItem(MODE_KEY) === "grid" ? "grid" : "freeform";
 }
 
 interface HudGridProps {
@@ -35,112 +39,97 @@ interface HudGridProps {
 
 export function HudGrid({ state, onRoll, onAdjustHp, layoutResetToken }: HudGridProps) {
   const { width, containerRef, mounted } = useContainerWidth();
-  const [layout, setLayout] = useState<Layout>(() => loadLayout());
+  const [gridLayout, setGridLayout] = useState<Layout>(() => loadGridLayout());
+  const [layoutMode, setLayoutMode] = useState<HudLayoutMode>(() => loadMode());
   const [die, setDie] = useState(20);
   const [modifier, setModifier] = useState(5);
   const hpPercent = Math.round((state.hp / state.maxHp) * 100);
 
   useEffect(() => {
-    if (layoutResetToken > 0) {
-      setLayout(DEFAULT_LAYOUT);
-      window.localStorage.removeItem(LAYOUT_KEY);
-    }
+    if (layoutResetToken <= 0) return;
+    setGridLayout(DEFAULT_GRID_LAYOUT);
+    window.localStorage.removeItem(GRID_LAYOUT_KEY);
   }, [layoutResetToken]);
 
-  const updateLayout = (next: Layout) => {
-    setLayout(next);
-    window.localStorage.setItem(LAYOUT_KEY, JSON.stringify(next));
+  const setMode = (mode: HudLayoutMode) => {
+    setLayoutMode(mode);
+    window.localStorage.setItem(MODE_KEY, mode);
   };
 
+  const updateGridLayout = (next: Layout) => {
+    setGridLayout(next);
+    window.localStorage.setItem(GRID_LAYOUT_KEY, JSON.stringify(next));
+  };
+
+  const widgets = useMemo<Record<string, ReactNode>>(() => ({
+    character: (
+      <WidgetFrame eyebrow="Character" title={state.characterName} meta={`#${state.sessionId.slice(-3)}`}>
+        <div className="vital-row">
+          <div><span className="vital-label">Hit points</span><strong className="hp-value">{state.hp}<small> / {state.maxHp}</small></strong></div>
+          <span className="hp-percent">{hpPercent}%</span>
+        </div>
+        <div className="hp-track"><span style={{ width: `${hpPercent}%` }} /></div>
+        <div className="action-cluster" aria-label="Adjust hit points">
+          {[-5, -1, 1, 5].map((delta) => <button className="game-button compact" type="button" key={delta} onClick={() => onAdjustHp(delta)}>{delta > 0 ? `+${delta}` : delta}</button>)}
+        </div>
+        <p className="widget-note">Server authoritative. Every accepted change becomes a durable event.</p>
+      </WidgetFrame>
+    ),
+    dice: (
+      <WidgetFrame eyebrow="Action" title="Dice rig" meta="Server RNG">
+        <div className="die-row">
+          {[4, 6, 8, 10, 12, 20, 100].map((sides) => <button className={`die-chip ${die === sides ? "active" : ""}`} type="button" key={sides} onClick={() => setDie(sides)}>d{sides}</button>)}
+        </div>
+        <label className="modifier-control"><span>Modifier</span><input type="number" min={-20} max={20} value={modifier} onChange={(event) => setModifier(Number(event.target.value))} /></label>
+        <button className="game-button primary roll-button" type="button" onClick={() => onRoll(die, modifier)}>Roll d{die} {modifier >= 0 ? `+${modifier}` : modifier}</button>
+        <div className="roll-result" aria-live="polite">
+          {state.latestRoll ? <><span>Latest</span><strong>{state.latestRoll.total}</strong><small>d{state.latestRoll.sides}: {state.latestRoll.natural} {state.latestRoll.modifier >= 0 ? "+" : ""}{state.latestRoll.modifier}</small></> : <p>No roll yet. Make the first move.</p>}
+        </div>
+      </WidgetFrame>
+    ),
+    events: (
+      <WidgetFrame eyebrow="Live feed" title="Table log" meta={`${state.eventSequence} events`}>
+        <div className="event-list" role="log" aria-live="polite">
+          {[...state.events].reverse().map((event) => (
+            <article className="event-row" key={event.sequence}>
+              <span className={`event-icon ${event.kind}`}>{event.kind === "roll" ? "◆" : event.kind === "hp" ? "♥" : "↪"}</span>
+              <div><p>{event.summary}</p><small>#{event.sequence} · {new Date(event.at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}</small></div>
+            </article>
+          ))}
+          {state.events.length === 0 ? <p className="empty-state">The table is quiet. Roll or change HP to create the first event.</p> : null}
+        </div>
+      </WidgetFrame>
+    )
+  }), [die, hpPercent, modifier, onAdjustHp, onRoll, state]);
+
+  const freeformItems: FreeformItem[] = [
+    { id: "character", initial: { x: 28, y: 64, width: 350, height: 330, z: 2 }, minWidth: 290, minHeight: 260, node: widgets.character },
+    { id: "dice", initial: { x: 405, y: 92, width: 390, height: 350, z: 3 }, minWidth: 310, minHeight: 270, node: widgets.dice },
+    { id: "events", initial: { x: 830, y: 54, width: 390, height: 530, z: 1 }, minWidth: 300, minHeight: 300, node: widgets.events }
+  ];
+
   return (
-    <main className="hud-stage" ref={containerRef}>
+    <main className={`hud-stage ${layoutMode === "freeform" ? "freeform-mode" : "grid-mode"}`} ref={containerRef}>
       <div className="stage-grid" aria-hidden="true" />
-      {mounted ? (
+      <div className="hud-layout-toolbar" role="group" aria-label="HUD layout mode">
+        <span>Layout</span>
+        <button type="button" className={layoutMode === "freeform" ? "active" : ""} onClick={() => setMode("freeform")}>Free</button>
+        <button type="button" className={layoutMode === "grid" ? "active" : ""} onClick={() => setMode("grid")}>Snap grid</button>
+      </div>
+
+      {layoutMode === "freeform" ? (
+        <FreeformSurface items={freeformItems} storageKey="utt.hud.freeform.v1" resetToken={layoutResetToken} className="hud-freeform" />
+      ) : mounted ? (
         <ReactGridLayout
           width={width}
-          layout={layout}
+          layout={gridLayout}
           gridConfig={{ cols: 12, rowHeight: 40, margin: [12, 12], containerPadding: [0, 0] }}
           dragConfig={{ enabled: true, handle: ".widget-handle" }}
           resizeConfig={{ enabled: true, handles: ["se", "e", "s"] }}
           compactor={verticalCompactor}
-          onLayoutChange={updateLayout}
+          onLayoutChange={updateGridLayout}
         >
-          <div key="character" data-widget="character">
-            <WidgetFrame eyebrow="Character" title={state.characterName} meta={`#${state.sessionId.slice(-3)}`}>
-              <div className="vital-row">
-                <div>
-                  <span className="vital-label">Hit points</span>
-                  <strong className="hp-value">{state.hp}<small> / {state.maxHp}</small></strong>
-                </div>
-                <span className="hp-percent">{hpPercent}%</span>
-              </div>
-              <div className="hp-track"><span style={{ width: `${hpPercent}%` }} /></div>
-              <div className="action-cluster" aria-label="Adjust hit points">
-                {[-5, -1, 1, 5].map((delta) => (
-                  <button className="game-button compact" type="button" key={delta} onClick={() => onAdjustHp(delta)}>
-                    {delta > 0 ? `+${delta}` : delta}
-                  </button>
-                ))}
-              </div>
-              <p className="widget-note">Server authoritative. Every accepted change becomes a durable event.</p>
-            </WidgetFrame>
-          </div>
-
-          <div key="dice" data-widget="dice">
-            <WidgetFrame eyebrow="Action" title="Dice rig" meta="Server RNG">
-              <div className="die-row">
-                {[4, 6, 8, 10, 12, 20, 100].map((sides) => (
-                  <button
-                    className={`die-chip ${die === sides ? "active" : ""}`}
-                    type="button"
-                    key={sides}
-                    onClick={() => setDie(sides)}
-                  >d{sides}</button>
-                ))}
-              </div>
-              <label className="modifier-control">
-                <span>Modifier</span>
-                <input
-                  type="number"
-                  min={-20}
-                  max={20}
-                  value={modifier}
-                  onChange={(event) => setModifier(Number(event.target.value))}
-                />
-              </label>
-              <button className="game-button primary roll-button" type="button" onClick={() => onRoll(die, modifier)}>
-                Roll d{die} {modifier >= 0 ? `+${modifier}` : modifier}
-              </button>
-              <div className="roll-result" aria-live="polite">
-                {state.latestRoll ? (
-                  <>
-                    <span>Latest</span>
-                    <strong>{state.latestRoll.total}</strong>
-                    <small>d{state.latestRoll.sides}: {state.latestRoll.natural} {state.latestRoll.modifier >= 0 ? "+" : ""}{state.latestRoll.modifier}</small>
-                  </>
-                ) : (
-                  <p>No roll yet. Make the first move.</p>
-                )}
-              </div>
-            </WidgetFrame>
-          </div>
-
-          <div key="events" data-widget="events">
-            <WidgetFrame eyebrow="Live feed" title="Table log" meta={`${state.eventSequence} events`}>
-              <div className="event-list" role="log" aria-live="polite">
-                {[...state.events].reverse().map((event) => (
-                  <article className="event-row" key={event.sequence}>
-                    <span className={`event-icon ${event.kind}`}>{event.kind === "roll" ? "◆" : event.kind === "hp" ? "♥" : "↪"}</span>
-                    <div>
-                      <p>{event.summary}</p>
-                      <small>#{event.sequence} · {new Date(event.at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}</small>
-                    </div>
-                  </article>
-                ))}
-                {state.events.length === 0 ? <p className="empty-state">The table is quiet. Roll or change HP to create the first event.</p> : null}
-              </div>
-            </WidgetFrame>
-          </div>
+          {Object.entries(widgets).map(([id, node]) => <div key={id} data-widget={id}>{node}</div>)}
         </ReactGridLayout>
       ) : null}
     </main>

--- a/apps/web/src/components/SceneCanvas.tsx
+++ b/apps/web/src/components/SceneCanvas.tsx
@@ -9,6 +9,8 @@ interface SceneCanvasProps {
   tokens: AtlasTokenDto[];
   clientName: string;
   selectedHotspotId: string | null;
+  selectedHotspotLore: string | null;
+  selectedHotspotLinkedSceneName: string | null;
   addPinMode: boolean;
   addTokenMode: boolean;
   onToggleAddPin: () => void;
@@ -16,6 +18,7 @@ interface SceneCanvasProps {
   onCanvasPoint: (point: { x: number; y: number }) => void;
   onTokenPoint: (point: { x: number; y: number }) => void;
   onHotspotSelect: (hotspot: AtlasHotspotDto) => void;
+  onHotspotEnter: (hotspot: AtlasHotspotDto) => void;
   onTokenMove: (tokenId: string, x: number, y: number) => void;
 }
 
@@ -48,13 +51,13 @@ function GridOverlay({ scene }: { scene: AtlasSceneDto }) {
 }
 
 export function SceneCanvas({
-  scene, hotspots, tokens, clientName, selectedHotspotId, addPinMode, addTokenMode, onToggleAddPin, onToggleAddToken,
-  onCanvasPoint, onTokenPoint, onHotspotSelect, onTokenMove
+  scene, hotspots, tokens, clientName, selectedHotspotId, selectedHotspotLore, selectedHotspotLinkedSceneName,
+  addPinMode, addTokenMode, onToggleAddPin, onToggleAddToken, onCanvasPoint, onTokenPoint, onHotspotSelect, onHotspotEnter, onTokenMove
 }: SceneCanvasProps) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<{ pointerId: number; x: number; y: number; cameraX: number; cameraY: number } | null>(null);
   const tokenDragRef = useRef<{ pointerId: number; tokenId: string; clientX: number; clientY: number; x: number; y: number } | null>(null);
-  const [draggedToken, setDraggedToken] = useState<{ id: string; x: number; y: number } | null>(null);
+  const [draggedToken, setDraggedToken] = useState<{ id: string; x: number; y: number; pending: boolean } | null>(null);
   const [camera, setCamera] = useState<CameraState>({ x: 0, y: 0, scale: 0.5 });
 
   const fit = useCallback(() => {
@@ -121,6 +124,20 @@ export function SceneCanvas({
     if (dragRef.current?.pointerId === event.pointerId) dragRef.current = null;
   };
 
+  useEffect(() => {
+    if (!draggedToken?.pending) return;
+    const authoritative = tokens.find((token) => token.id === draggedToken.id);
+    if (!authoritative) return;
+    const converged = Math.abs(authoritative.x - draggedToken.x) < 0.0005 && Math.abs(authoritative.y - draggedToken.y) < 0.0005;
+    if (converged) setDraggedToken(null);
+  }, [draggedToken, tokens]);
+
+  useEffect(() => {
+    if (!draggedToken?.pending) return;
+    const timer = window.setTimeout(() => setDraggedToken((current) => current?.id === draggedToken.id && current.pending ? null : current), 1600);
+    return () => window.clearTimeout(timer);
+  }, [draggedToken]);
+
   const canControlToken = (token: AtlasTokenDto) => !token.controllerName || token.controllerName === clientName;
 
   const startTokenDrag = (event: ReactPointerEvent<HTMLButtonElement>, token: AtlasTokenDto) => {
@@ -128,7 +145,7 @@ export function SceneCanvas({
     if (event.button !== 0 || !canControlToken(token)) return;
     event.currentTarget.setPointerCapture(event.pointerId);
     tokenDragRef.current = { pointerId: event.pointerId, tokenId: token.id, clientX: event.clientX, clientY: event.clientY, x: token.x, y: token.y };
-    setDraggedToken({ id: token.id, x: token.x, y: token.y });
+    setDraggedToken({ id: token.id, x: token.x, y: token.y, pending: false });
   };
 
   const moveTokenDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
@@ -137,16 +154,16 @@ export function SceneCanvas({
     event.stopPropagation();
     const x = clamp(drag.x + (event.clientX - drag.clientX) / (camera.scale * scene.backgroundWidth), 0, 1);
     const y = clamp(drag.y + (event.clientY - drag.clientY) / (camera.scale * scene.backgroundHeight), 0, 1);
-    setDraggedToken({ id: drag.tokenId, x, y });
+    setDraggedToken({ id: drag.tokenId, x, y, pending: false });
   };
 
   const finishTokenDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
     const drag = tokenDragRef.current;
     if (!drag || drag.pointerId !== event.pointerId) return;
     event.stopPropagation();
-    const finalPosition = draggedToken?.id === drag.tokenId ? draggedToken : { id: drag.tokenId, x: drag.x, y: drag.y };
+    const finalPosition = draggedToken?.id === drag.tokenId ? draggedToken : { id: drag.tokenId, x: drag.x, y: drag.y, pending: false };
     tokenDragRef.current = null;
-    setDraggedToken(null);
+    setDraggedToken({ id: drag.tokenId, x: finalPosition.x, y: finalPosition.y, pending: true });
     onTokenMove(drag.tokenId, finalPosition.x, finalPosition.y);
   };
 
@@ -186,18 +203,34 @@ export function SceneCanvas({
           })}
         </div>
         <div className="hotspot-layer">
-          {hotspots.map((hotspot) => (
-            <button
-              type="button"
-              key={hotspot.id}
-              className={`scene-hotspot ${selectedHotspotId === hotspot.id ? "selected" : ""}`}
-              style={{ left: `${hotspot.x * 100}%`, top: `${hotspot.y * 100}%`, transform: `translate(-50%, -100%) scale(${1 / camera.scale})` }}
-              onPointerDown={(event) => event.stopPropagation()}
-              onClick={(event) => { event.stopPropagation(); onHotspotSelect(hotspot); }}
-            >
-              <span className="hotspot-dot">◆</span><span className="hotspot-label">{hotspot.label}</span>
-            </button>
-          ))}
+          {hotspots.map((hotspot) => {
+            const selected = selectedHotspotId === hotspot.id;
+            return (
+              <div
+                key={hotspot.id}
+                className={`scene-hotspot-anchor ${selected ? "selected" : ""}`}
+                style={{ left: `${hotspot.x * 100}%`, top: `${hotspot.y * 100}%`, transform: `translate(-50%, -100%) scale(${1 / camera.scale})` }}
+                onPointerDown={(event) => event.stopPropagation()}
+              >
+                <button
+                  type="button"
+                  className={`scene-hotspot ${selected ? "selected" : ""}`}
+                  aria-label={`Open ${hotspot.label} hotspot`}
+                  onClick={(event) => { event.stopPropagation(); onHotspotSelect(hotspot); }}
+                  onDoubleClick={(event) => { event.stopPropagation(); if (hotspot.linkedSceneId) onHotspotEnter(hotspot); }}
+                >
+                  <span className="hotspot-dot"><i>◆</i></span><span className="hotspot-label">{hotspot.label}</span>
+                </button>
+                {selected ? (
+                  <div className="hotspot-popover">
+                    <strong>{hotspot.label}</strong>
+                    <p>{selectedHotspotLore || "No lore summary attached yet."}</p>
+                    {hotspot.linkedSceneId ? <button type="button" className="game-button primary" onClick={() => onHotspotEnter(hotspot)}>Open {selectedHotspotLinkedSceneName || "linked scene"}</button> : null}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -306,3 +306,62 @@ button { color: inherit; }
 .atlas-sheet .claim-control input { width: auto; }
 .sheet-note { margin: 0; color: #646b76; font-size: 9px; line-height: 1.5; }
 .event-icon.token_created, .event-icon.token_moved { color: var(--arcane); }
+
+
+/* VS003.5 — freeform workspaces + interaction stabilization */
+.ghost-button.active { border-color: rgba(99,200,189,.35); color: #c8f1eb; background: rgba(99,200,189,.07); }
+.hud-stage.freeform-mode { overflow: auto; padding: 0; }
+.hud-stage.freeform-mode .stage-grid { inset: 0; }
+.hud-layout-toolbar {
+  position: absolute; z-index: 40; top: 12px; left: 18px; display: flex; align-items: center; gap: 3px;
+  padding: 3px; border: 1px solid rgba(255,255,255,.09); border-radius: 9px;
+  background: rgba(8,10,14,.9); backdrop-filter: blur(12px); box-shadow: 0 8px 24px rgba(0,0,0,.3);
+}
+.hud-layout-toolbar span { padding: 0 7px; color: #747b87; font: 9px ui-monospace, monospace; text-transform: uppercase; letter-spacing: .08em; }
+.hud-layout-toolbar button { border: 0; border-radius: 6px; padding: 6px 9px; background: transparent; color: #969da8; cursor: pointer; font-size: 10px; }
+.hud-layout-toolbar button.active { color: #f0dfc4; background: rgba(197,156,91,.14); }
+
+.freeform-surface { position: relative; z-index: 1; min-width: 1240px; min-height: 720px; height: max(720px, calc(100vh - 102px)); }
+.freeform-surface.overlay { position: absolute; z-index: 24; inset: 0; min-width: 0; min-height: 0; height: auto; pointer-events: none; overflow: hidden; }
+.freeform-item { position: absolute; pointer-events: auto; touch-action: none; }
+.freeform-item > .hud-widget { width: 100%; height: 100%; }
+.freeform-item:focus-within { z-index: 100 !important; }
+.freeform-resize-handle {
+  position: absolute; z-index: 5; right: 3px; bottom: 3px; width: 18px; height: 18px; padding: 0;
+  border: 0; border-radius: 5px; background: transparent; cursor: nwse-resize; touch-action: none;
+}
+.freeform-resize-handle::before, .freeform-resize-handle::after {
+  content: ""; position: absolute; right: 3px; bottom: 3px; border-right: 1px solid rgba(224,189,130,.68); border-bottom: 1px solid rgba(224,189,130,.68);
+}
+.freeform-resize-handle::before { width: 9px; height: 9px; }
+.freeform-resize-handle::after { width: 5px; height: 5px; right: 7px; bottom: 7px; opacity: .55; }
+.freeform-item .widget-handle { touch-action: none; }
+.hud-freeform { padding-top: 0; }
+
+.scene-column { position: relative; }
+.director-freeform .hud-widget { background: linear-gradient(165deg, rgba(19,23,30,.94), rgba(10,12,17,.92)); backdrop-filter: blur(10px); }
+.director-freeform .widget-handle { min-height: 52px; padding: 9px 11px; }
+.director-freeform .widget-handle h2 { font-size: 15px; }
+.director-freeform .widget-body { gap: 9px; padding: 11px; }
+.director-widget-copy span { color: var(--arcane); font: 9px ui-monospace, monospace; text-transform: uppercase; letter-spacing: .06em; }
+.director-widget-copy p, .director-lore-copy { margin: 7px 0 0; color: #8b929e; font-size: 10px; line-height: 1.5; }
+.director-token-roster { min-height: 0; overflow: auto; }
+
+.scene-hotspot-anchor { position: absolute; z-index: 9; transform-origin: 50% 100%; pointer-events: auto; }
+.scene-hotspot-anchor .scene-hotspot { position: relative; left: auto; top: auto; transform: none; z-index: 1; }
+.hotspot-dot i { display: block; transform: rotate(45deg); font-style: normal; }
+.hotspot-popover {
+  position: absolute; z-index: 12; left: 38px; top: -6px; width: 230px; display: flex; flex-direction: column; gap: 8px;
+  padding: 10px; border: 1px solid rgba(197,156,91,.25); border-radius: 10px;
+  background: rgba(10,12,17,.96); box-shadow: 0 16px 44px rgba(0,0,0,.58); backdrop-filter: blur(12px);
+}
+.hotspot-popover::before { content: ""; position: absolute; left: -6px; top: 18px; width: 10px; height: 10px; transform: rotate(45deg); border-left: 1px solid rgba(197,156,91,.25); border-bottom: 1px solid rgba(197,156,91,.25); background: rgba(10,12,17,.96); }
+.hotspot-popover strong { color: #eee6d9; font: 600 13px Georgia, serif; }
+.hotspot-popover p { margin: 0; color: #8e96a2; font-size: 9px; line-height: 1.45; }
+.hotspot-popover .game-button { min-height: 30px; padding: 5px 8px; font-size: 9px; }
+
+@media (max-width: 720px) {
+  .hud-layout-toolbar { position: sticky; top: 8px; width: max-content; margin: 8px 10px 0; }
+  .freeform-surface:not(.overlay) { min-width: 980px; min-height: 680px; }
+  .director-freeform { display: none; }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,11 +1,11 @@
 # Architecture
 
-Status: **foundation + Vertical Slice 003 authoritative tokens**
+Status: **foundation + Vertical Slice 003.5 table UX stabilization**
 
 ## Boundary model
 
 ```text
-React UI / DOM HUD + Scene Atlas
+React UI / freeform DOM workspaces + Scene Atlas
         |                \
         | live intents    \ durable world edits / assets
         v                  v
@@ -55,7 +55,7 @@ The model deliberately permits partial entities. A scene may exist without lore;
 
 **Durable asset state:** uploaded PNG/JPEG/WebP bytes in the private `scene-assets` Docker volume. SurrealDB stores only generated asset keys and image dimensions.
 
-**Presentation state:** pan/zoom, current private browse scene, selected hotspot and HUD layout. These are not game truth.
+**Presentation state:** pan/zoom, current private browse scene, selected hotspot, freeform widget placements/z-order and optional snap-grid layout. These are not game truth. Live and Director use the same role-neutral freeform primitive with different widget content.
 
 ## Not implemented yet
 

--- a/docs/VERTICAL-SLICE-003-5.md
+++ b/docs/VERTICAL-SLICE-003-5.md
@@ -1,0 +1,39 @@
+# Vertical Slice 003.5 — Table UX stabilization
+
+Status: **complete / proven on homelab — 2026-08-16**.
+
+## Why this slice exists
+VS003 proved authoritative tokens, but two interaction problems were visible before adding walls/vision: accepted token drags briefly snapped back while waiting for the Colyseus patch, and HUD widgets were draggable only inside a compacting grid. Director controls also needed the same customization philosophy as player-facing tools.
+
+## Implemented behavior
+- role-neutral `FreeformSurface` primitive for DOM widgets;
+- freeform pixel positioning with overlap allowed and no automatic compaction;
+- free resize with minimum sizes;
+- bring-to-front behavior through persisted z-order;
+- per-workspace local persistence;
+- optional legacy `Snap grid` mode remains available for Live;
+- Live defaults to `Free` mode;
+- Director uses the same freeform primitive for floating scene/token tools;
+- Director floating tools can be hidden and reset independently;
+- map interaction remains available outside floating widgets;
+- accepted token movement keeps its optimistic visual position until authoritative state converges;
+- a timeout rolls the preview back if no authoritative confirmation arrives;
+- hotspot selection now opens an inline map popover with lore summary and linked-scene action;
+- double-clicking a linked hotspot enters its scene.
+
+## Browser evidence
+Chromium QA against the real Tailscale preview intentionally dragged the Character widget into the Dice widget. The resulting overlap area was about `108,850 px²`, proving there is no collision/compaction requirement in Free mode.
+
+The Character widget was resized by more than 80 px horizontally and 50 px vertically; its position, dimensions and z-order survived a full reload through local storage. The same run switched to `Snap grid` and back to `Free`, proving both modes remain usable.
+
+A Director pass overlapped the Scene and Token Roster floating tools by about `52,710 px²` with zero console/page errors. The Greyhaven hotspot opened its contextual map popover and exposed `Open Greyhaven Gate` without requiring the right inspector.
+
+A live token drag sampled the token position every 25 ms for roughly 450 ms after pointer release. Maximum excursion from the final accepted position was `0 px`, removing the successful-move rubber-band observed in VS003.
+
+A 390×844 browser viewport connected and rendered Live Freeform with zero console/page errors.
+
+## State boundary
+Widget positions, sizes, z-order and chosen layout mode are presentation state stored locally. They are not synchronized through Colyseus and are not world/session truth. DM and player roles may eventually have different widget catalogs and permissions while sharing this same layout primitive.
+
+## Explicit non-goals
+This slice does not implement authenticated DM/player roles, shared/cloud workspace presets, widget catalogs, hide/show management for every widget, multi-select/grouping, walls, doors, fog/vision, targeting or initiative. Those remain later milestones.

--- a/docs/adr/0007-dom-widget-hud.md
+++ b/docs/adr/0007-dom-widget-hud.md
@@ -1,6 +1,6 @@
 # ADR 0007 — DOM-based configurable HUD
 
-Status: Accepted
+Status: Accepted, amended by ADR 0014
 
 ## Context
 
@@ -9,6 +9,8 @@ UTT live UI is text/control dense and must remain accessible, draggable, resizab
 ## Decision
 
 Render HUD widgets in React DOM and use React-Grid-Layout v2 for the first layout primitive. Keep presentation layout outside authoritative game state.
+
+ADR 0014 later keeps the DOM decision but changes layout policy: freeform placement is primary and React Grid Layout is an optional Snap Grid mode.
 
 ## Alternatives considered
 

--- a/docs/adr/0014-freeform-role-neutral-workspaces.md
+++ b/docs/adr/0014-freeform-role-neutral-workspaces.md
@@ -1,0 +1,19 @@
+# ADR 0014 — Freeform, role-neutral workspaces
+
+Status: Accepted
+
+## Context
+React Grid Layout gave VS001 a fast draggable/resizable HUD, but its cell model and compaction make widgets behave like dashboard tiles. UTT wants a game-like surface where tools may overlap, float around a map and differ by role without requiring separate layout engines.
+
+## Decision
+Keep DOM widgets, but make a small role-neutral `FreeformSurface` the primary customization primitive. It stores local `x`, `y`, `width`, `height` and `z` values, permits overlap, and does not compact neighbors. Presentation state remains local and outside authoritative game state.
+
+React Grid Layout remains available as an optional Snap Grid mode rather than the foundational layout model. Director and player workspaces must be able to use the same FreeformSurface with different widget catalogs and permissions.
+
+## Consequences
+- users can place widgets without invisible grid constraints;
+- overlap and manual layering are first-class;
+- DM and player experiences can share interaction behavior while exposing different tools;
+- grid users retain a structured option;
+- future workspace presets can serialize the same placement shape;
+- collision avoidance, multi-select and cloud-synced presets are deliberately deferred.


### PR DESCRIPTION
## Summary

Stabilizes the shared tabletop UX before walls/vision work.

### Freeform workspaces
- Live now defaults to a true freeform widget surface: no mandatory grid, no automatic compaction, overlap allowed.
- Widgets persist x/y/width/height/z locally and bring themselves to front when interacted with.
- The previous React Grid Layout behavior remains available as optional **Snap grid** mode.
- Director uses the same role-neutral freeform primitive for floating scene/token tools, so DM and player customization can evolve from one interaction model.

### Interaction fixes
- Accepted token drags keep their optimistic position until Colyseus confirms the authoritative coordinates, removing the visible snap-back/rubber-band.
- Hotspots now open a contextual map popover with lore and linked-scene navigation; linked pins can also be entered by double click.
- Director/Live labels now reflect the intended product split while sharing the same session runtime.

### Verification
- Remote Git tree is byte-for-byte identical to the locally verified commit tree (`a738ac032d8bad24112bd5c126063f028479978d`).
- `pnpm check` green: strict TypeScript, ESLint, 18/18 tests, production builds.
- Browser QA on the real Tailscale preview: ~108,850 px² Live widget overlap, resize + reload persistence, Snap Grid toggle, 0 px post-release token excursion, zero console/page errors.
- Director floating widgets overlapped successfully (~52,710 px²) and the Greyhaven hotspot popover was verified.
- 390×844 mobile Live smoke passed with zero console/page errors.

No backend/domain protocol changes and no new public exposure are introduced.