### PR TITLE
VS003.6 — unified Virtual Table and Companion play

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ The product goal is one continuous tool for world building, lore, scene navigati
 - optimistic token movement held until authoritative confirmation, removing accepted-move rubber-band;
 - contextual map popovers for scene/lore hotspots.
 
+**Vertical Slice 003.6** unifies the actual play experience:
+
+- Virtual Table uses the active scene/map + synchronized tokens as the base live surface;
+- the same Character/Dice/Log widgets float above the map;
+- Companion preserves a map-free surface for physical play;
+- Companion can use connected campaign state or explicit browser-local offline state;
+- mobile Virtual Table uses a compact HUD drawer so the map remains visible.
+
 Walls/doors, fog/vision, initiative/targeting, travel rules, hex-map generation, auth/roles, secret-lore authorization and the Content/Character/Action/Effect engines remain intentionally separate milestones.
 
 ## Development architecture
@@ -57,6 +65,7 @@ Only the gateway is published to the homelab Tailscale address. SurrealDB, Colys
 - `docs/VERTICAL-SLICE-002.md` — Scene Atlas foundation evidence
 - `docs/VERTICAL-SLICE-003.md` — authoritative token foundation evidence
 - `docs/VERTICAL-SLICE-003-5.md` — freeform workspace and interaction stabilization evidence
+- `docs/VERTICAL-SLICE-003-6.md` — unified Virtual Table / Companion evidence
 - `docs/LEGACY-REVIEW.md` — what v0.0.4 may and may not influence
 - `docs/adr/` — architecture decision records
 - `docs/RUNBOOK.md` — operator/developer commands

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,76 +1,48 @@
 import { useState } from "react";
 import { AtlasWorkspace } from "./components/AtlasWorkspace.js";
-import { HudGrid } from "./components/HudGrid.js";
+import { PlayWorkspace } from "./components/PlayWorkspace.js";
 import { useLiveRoom } from "./live-room.js";
+
+type AppView = "director" | "play";
+
+function loadView(): AppView {
+  return window.localStorage.getItem("utt.workspace.v1") === "director" ? "director" : "play";
+}
 
 export function App() {
   const live = useLiveRoom();
-  const [layoutResetToken, setLayoutResetToken] = useState(0);
-  const [view, setView] = useState<"atlas" | "hud">("atlas");
+  const [view, setViewState] = useState<AppView>(() => loadView());
+  const campaignState = live.status === "connected" ? live.state : null;
+  const setView = (next: AppView) => { setViewState(next); window.localStorage.setItem("utt.workspace.v1", next); };
 
   return (
     <div className="app-shell">
       <header className="topbar">
-        <div className="brand-lockup">
-          <span className="brand-mark">UTT</span>
-          <div>
-            <strong>Under The Table</strong>
-            <span>Vertical Slice 003.5 · Table UX</span>
-          </div>
-        </div>
+        <div className="brand-lockup"><span className="brand-mark">UTT</span><div><strong>Under The Table</strong><span>Vertical Slice 003.6 · Unified Play</span></div></div>
 
         <div className="session-strip">
-          <span className={`status-pip ${live.status}`} />
-          <span>{live.status}</span>
-          <span className="divider" />
-          <span>{live.clientName}</span>
-          {live.state ? <><span className="divider" /><span>{live.state.connectedPlayers} connected</span></> : null}
+          <span className={`status-pip ${live.status}`} /><span>{live.status}</span><span className="divider" /><span>{live.clientName}</span>
+          {campaignState ? <><span className="divider" /><span>{campaignState.connectedPlayers} connected</span></> : null}
         </div>
 
         <div className="topbar-actions">
           <div className="view-switch" aria-label="Workspace view">
-            <button className={view === "atlas" ? "active" : ""} type="button" onClick={() => setView("atlas")}>Director</button>
-            <button className={view === "hud" ? "active" : ""} type="button" onClick={() => setView("hud")}>Live</button>
+            <button className={view === "director" ? "active" : ""} type="button" onClick={() => setView("director")}>Director</button>
+            <button className={view === "play" ? "active" : ""} type="button" onClick={() => setView("play")}>Play</button>
           </div>
           <span className="environment-badge">TAILSCALE DEV</span>
-          {view === "hud" ? <button className="ghost-button" type="button" onClick={() => setLayoutResetToken((value) => value + 1)}>Reset HUD</button> : null}
         </div>
       </header>
 
-      {live.error ? (
-        <div className="error-banner">
-          <span>{live.error}</span>
-          <button type="button" onClick={live.reconnect}>Reconnect</button>
-        </div>
-      ) : null}
+      {view === "director" && live.error ? <div className="error-banner"><span>{live.error}</span><button type="button" onClick={live.reconnect}>Reconnect</button></div> : null}
 
-      {live.state ? (
-        view === "atlas" ? (
-          <AtlasWorkspace
-            activeSceneId={live.state.activeSceneId}
-            liveTokens={live.state.tokens}
-            clientName={live.clientName}
-            tokenRevision={live.state.events[live.state.events.length - 1]?.kind.startsWith("token_") ? live.state.eventSequence : 0}
-            onPresentScene={live.presentScene}
-            onCreateToken={live.createToken}
-            onMoveToken={live.moveToken}
-          />
-        ) : (
-          <HudGrid state={live.state} onRoll={live.roll} onAdjustHp={live.adjustHp} layoutResetToken={layoutResetToken} />
-        )
+      {view === "director" ? (
+        campaignState ? <AtlasWorkspace activeSceneId={campaignState.activeSceneId} liveTokens={campaignState.tokens} clientName={live.clientName} tokenRevision={campaignState.events[campaignState.events.length - 1]?.kind.startsWith("token_") ? campaignState.eventSequence : 0} onPresentScene={live.presentScene} onCreateToken={live.createToken} onMoveToken={live.moveToken} /> : <main className="connecting-screen"><div className="sigil">UTT</div><h1>Opening the director table…</h1><p>Director needs the authoritative campaign runtime.</p><button className="game-button primary" type="button" onClick={() => setView("play")}>Use Play offline</button>{live.status === "disconnected" ? <button className="ghost-button" type="button" onClick={live.reconnect}>Try campaign again</button> : null}</main>
       ) : (
-        <main className="connecting-screen">
-          <div className="sigil">UTT</div>
-          <h1>Opening the table…</h1>
-          <p>Connecting to the authoritative session runtime.</p>
-          {live.status === "disconnected" ? <button className="game-button primary" type="button" onClick={live.reconnect}>Try again</button> : null}
-        </main>
+        <PlayWorkspace campaignState={campaignState} clientName={live.clientName} connectionStatus={live.status} connectionError={live.error} onRoll={live.roll} onAdjustHp={live.adjustHp} onMoveToken={live.moveToken} onReconnect={live.reconnect} />
       )}
 
-      <footer className="footer-note">
-        <span>{view === "atlas" ? "Director workspace" : "Live workspace"}</span>
-        <span>{view === "atlas" ? "Browse privately · present · floating DM tools" : "Freeform or snap-grid widgets · overlap allowed"}</span>
-      </footer>
+      <footer className="footer-note"><span>{view === "director" ? "Director workspace" : "Play workspace"}</span><span>{view === "director" ? "Browse privately · prepare · present" : "Virtual table or physical companion · one session model"}</span></footer>
     </div>
   );
 }

--- a/apps/web/src/components/HudGrid.tsx
+++ b/apps/web/src/components/HudGrid.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import ReactGridLayout, { useContainerWidth, verticalCompactor, type Layout } from "react-grid-layout";
 import type { LiveViewState } from "../live-room.js";
 import { FreeformSurface, type FreeformItem } from "./FreeformSurface.js";
-import { WidgetFrame } from "./WidgetFrame.js";
+import { useSessionHudWidgets } from "./SessionHudWidgets.js";
 
 const GRID_LAYOUT_KEY = "utt.vs001.layout";
 const MODE_KEY = "utt.hud.layout-mode.v1";
@@ -35,15 +35,14 @@ interface HudGridProps {
   onRoll: (sides: number, modifier: number) => void;
   onAdjustHp: (delta: number) => void;
   layoutResetToken: number;
+  authority?: "campaign" | "offline";
 }
 
-export function HudGrid({ state, onRoll, onAdjustHp, layoutResetToken }: HudGridProps) {
+export function HudGrid({ state, onRoll, onAdjustHp, layoutResetToken, authority = "campaign" }: HudGridProps) {
   const { width, containerRef, mounted } = useContainerWidth();
   const [gridLayout, setGridLayout] = useState<Layout>(() => loadGridLayout());
   const [layoutMode, setLayoutMode] = useState<HudLayoutMode>(() => loadMode());
-  const [die, setDie] = useState(20);
-  const [modifier, setModifier] = useState(5);
-  const hpPercent = Math.round((state.hp / state.maxHp) * 100);
+  const widgets = useSessionHudWidgets({ state, onRoll, onAdjustHp, authority });
 
   useEffect(() => {
     if (layoutResetToken <= 0) return;
@@ -61,47 +60,6 @@ export function HudGrid({ state, onRoll, onAdjustHp, layoutResetToken }: HudGrid
     window.localStorage.setItem(GRID_LAYOUT_KEY, JSON.stringify(next));
   };
 
-  const widgets = useMemo<Record<string, ReactNode>>(() => ({
-    character: (
-      <WidgetFrame eyebrow="Character" title={state.characterName} meta={`#${state.sessionId.slice(-3)}`}>
-        <div className="vital-row">
-          <div><span className="vital-label">Hit points</span><strong className="hp-value">{state.hp}<small> / {state.maxHp}</small></strong></div>
-          <span className="hp-percent">{hpPercent}%</span>
-        </div>
-        <div className="hp-track"><span style={{ width: `${hpPercent}%` }} /></div>
-        <div className="action-cluster" aria-label="Adjust hit points">
-          {[-5, -1, 1, 5].map((delta) => <button className="game-button compact" type="button" key={delta} onClick={() => onAdjustHp(delta)}>{delta > 0 ? `+${delta}` : delta}</button>)}
-        </div>
-        <p className="widget-note">Server authoritative. Every accepted change becomes a durable event.</p>
-      </WidgetFrame>
-    ),
-    dice: (
-      <WidgetFrame eyebrow="Action" title="Dice rig" meta="Server RNG">
-        <div className="die-row">
-          {[4, 6, 8, 10, 12, 20, 100].map((sides) => <button className={`die-chip ${die === sides ? "active" : ""}`} type="button" key={sides} onClick={() => setDie(sides)}>d{sides}</button>)}
-        </div>
-        <label className="modifier-control"><span>Modifier</span><input type="number" min={-20} max={20} value={modifier} onChange={(event) => setModifier(Number(event.target.value))} /></label>
-        <button className="game-button primary roll-button" type="button" onClick={() => onRoll(die, modifier)}>Roll d{die} {modifier >= 0 ? `+${modifier}` : modifier}</button>
-        <div className="roll-result" aria-live="polite">
-          {state.latestRoll ? <><span>Latest</span><strong>{state.latestRoll.total}</strong><small>d{state.latestRoll.sides}: {state.latestRoll.natural} {state.latestRoll.modifier >= 0 ? "+" : ""}{state.latestRoll.modifier}</small></> : <p>No roll yet. Make the first move.</p>}
-        </div>
-      </WidgetFrame>
-    ),
-    events: (
-      <WidgetFrame eyebrow="Live feed" title="Table log" meta={`${state.eventSequence} events`}>
-        <div className="event-list" role="log" aria-live="polite">
-          {[...state.events].reverse().map((event) => (
-            <article className="event-row" key={event.sequence}>
-              <span className={`event-icon ${event.kind}`}>{event.kind === "roll" ? "◆" : event.kind === "hp" ? "♥" : "↪"}</span>
-              <div><p>{event.summary}</p><small>#{event.sequence} · {new Date(event.at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}</small></div>
-            </article>
-          ))}
-          {state.events.length === 0 ? <p className="empty-state">The table is quiet. Roll or change HP to create the first event.</p> : null}
-        </div>
-      </WidgetFrame>
-    )
-  }), [die, hpPercent, modifier, onAdjustHp, onRoll, state]);
-
   const freeformItems: FreeformItem[] = [
     { id: "character", initial: { x: 28, y: 64, width: 350, height: 330, z: 2 }, minWidth: 290, minHeight: 260, node: widgets.character },
     { id: "dice", initial: { x: 405, y: 92, width: 390, height: 350, z: 3 }, minWidth: 310, minHeight: 270, node: widgets.dice },
@@ -109,7 +67,7 @@ export function HudGrid({ state, onRoll, onAdjustHp, layoutResetToken }: HudGrid
   ];
 
   return (
-    <main className={`hud-stage ${layoutMode === "freeform" ? "freeform-mode" : "grid-mode"}`} ref={containerRef}>
+    <section className={`hud-stage ${layoutMode === "freeform" ? "freeform-mode" : "grid-mode"}`} ref={containerRef}>
       <div className="stage-grid" aria-hidden="true" />
       <div className="hud-layout-toolbar" role="group" aria-label="HUD layout mode">
         <span>Layout</span>
@@ -132,6 +90,6 @@ export function HudGrid({ state, onRoll, onAdjustHp, layoutResetToken }: HudGrid
           {Object.entries(widgets).map(([id, node]) => <div key={id} data-widget={id}>{node}</div>)}
         </ReactGridLayout>
       ) : null}
-    </main>
+    </section>
   );
 }

--- a/apps/web/src/components/PlayWorkspace.tsx
+++ b/apps/web/src/components/PlayWorkspace.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from "react";
+import { useAtlas } from "../atlas.js";
+import type { LiveViewState } from "../live-room.js";
+import { useOfflineCompanion } from "../offline-companion.js";
+import { FreeformSurface, type FreeformItem } from "./FreeformSurface.js";
+import { HudGrid } from "./HudGrid.js";
+import { SceneCanvas } from "./SceneCanvas.js";
+import { useSessionHudWidgets } from "./SessionHudWidgets.js";
+
+type PlayMode = "table" | "companion";
+type CompanionSource = "campaign" | "offline";
+type MobileWidget = "character" | "dice" | "events";
+
+interface PlayWorkspaceProps {
+  campaignState: LiveViewState | null;
+  clientName: string;
+  connectionStatus: "connecting" | "connected" | "disconnected";
+  connectionError: string | null;
+  onRoll: (sides: number, modifier: number) => void;
+  onAdjustHp: (delta: number) => void;
+  onMoveToken: (tokenId: string, x: number, y: number) => void;
+  onReconnect: () => void;
+}
+
+function loadPlayMode(): PlayMode {
+  return window.localStorage.getItem("utt.play.mode.v1") === "companion" ? "companion" : "table";
+}
+
+function loadCompanionSource(): CompanionSource {
+  return window.localStorage.getItem("utt.play.companion-source.v1") === "offline" ? "offline" : "campaign";
+}
+
+function VirtualTable({ state, clientName, onRoll, onAdjustHp, onMoveToken, showHud, resetToken }: {
+  state: LiveViewState;
+  clientName: string;
+  onRoll: (sides: number, modifier: number) => void;
+  onAdjustHp: (delta: number) => void;
+  onMoveToken: (tokenId: string, x: number, y: number) => void;
+  showHud: boolean;
+  resetToken: number;
+}) {
+  const atlas = useAtlas();
+  const widgets = useSessionHudWidgets({ state, onRoll, onAdjustHp, authority: "campaign" });
+  const [mobileWidget, setMobileWidget] = useState<MobileWidget>("character");
+  const scene = atlas.data?.scenes.find((item) => item.id === state.activeSceneId) ?? null;
+
+  useEffect(() => {
+    if (atlas.data && state.activeSceneId && !scene) void atlas.refresh();
+  }, [atlas.data, atlas.refresh, scene, state.activeSceneId]);
+
+  if (atlas.loading && !scene) return <section className="play-table-loading">Loading active scene…</section>;
+  if (!scene) return <section className="play-table-loading"><strong>Active scene unavailable</strong><span>{atlas.error ?? "Waiting for Atlas data."}</span></section>;
+
+  const items: FreeformItem[] = [
+    { id: "character", initial: { x: 24, y: 74, width: 330, height: 300, z: 3 }, minWidth: 280, minHeight: 240, node: widgets.character },
+    { id: "dice", initial: { x: 382, y: 96, width: 350, height: 330, z: 2 }, minWidth: 300, minHeight: 260, node: widgets.dice },
+    { id: "events", initial: { x: 760, y: 60, width: 350, height: 450, z: 1 }, minWidth: 290, minHeight: 280, node: widgets.events }
+  ];
+
+  return (
+    <section className="play-table-stage">
+      <div className="play-scene-title"><span>On table</span><strong>{scene.name}</strong></div>
+      <SceneCanvas
+        mode="play"
+        scene={scene}
+        hotspots={[]}
+        tokens={state.tokens}
+        clientName={clientName}
+        selectedHotspotId={null}
+        selectedHotspotLore={null}
+        onTokenMove={onMoveToken}
+      />
+      {showHud ? <>
+        <FreeformSurface items={items} storageKey="utt.play.table.freeform.v1" resetToken={resetToken} overlay className="play-hud-freeform" />
+        <div className="play-mobile-hud">
+          <div className="play-mobile-widget">{widgets[mobileWidget]}</div>
+          <nav className="play-mobile-dock" aria-label="Live HUD widgets">
+            {(["character", "dice", "events"] as MobileWidget[]).map((id) => <button type="button" className={mobileWidget === id ? "active" : ""} key={id} onClick={() => setMobileWidget(id)}>{id === "character" ? "Character" : id === "dice" ? "Dice" : "Log"}</button>)}
+          </nav>
+        </div>
+      </> : null}
+    </section>
+  );
+}
+
+export function PlayWorkspace({ campaignState, clientName, connectionStatus, connectionError, onRoll, onAdjustHp, onMoveToken, onReconnect }: PlayWorkspaceProps) {
+  const offline = useOfflineCompanion(campaignState);
+  const [mode, setModeState] = useState<PlayMode>(() => loadPlayMode());
+  const [companionSource, setCompanionSourceState] = useState<CompanionSource>(() => loadCompanionSource());
+  const [showHud, setShowHud] = useState(true);
+  const [resetToken, setResetToken] = useState(0);
+  useEffect(() => {
+    if (companionSource !== "campaign" || campaignState || connectionStatus !== "disconnected") return;
+    setCompanionSourceState("offline");
+    window.localStorage.setItem("utt.play.companion-source.v1", "offline");
+  }, [campaignState, companionSource, connectionStatus]);
+
+  const effectiveSource: CompanionSource = companionSource === "campaign" && campaignState ? "campaign" : "offline";
+  const companionState = effectiveSource === "campaign" && campaignState ? campaignState : offline.state;
+
+  const setMode = (next: PlayMode) => { setModeState(next); window.localStorage.setItem("utt.play.mode.v1", next); };
+  const setCompanionSource = (next: CompanionSource) => { setCompanionSourceState(next); window.localStorage.setItem("utt.play.companion-source.v1", next); };
+
+  return (
+    <main className="play-workspace">
+      <header className="play-toolbar">
+        <div className="play-mode-switch" role="group" aria-label="Play surface">
+          <button type="button" className={mode === "table" ? "active" : ""} disabled={!campaignState} onClick={() => setMode("table")}>Virtual Table</button>
+          <button type="button" className={mode === "companion" ? "active" : ""} onClick={() => setMode("companion")}>Companion</button>
+        </div>
+        <div className="play-toolbar-status"><span className={`status-pip ${connectionStatus}`} /><span>{campaignState ? "Campaign connected" : "No live campaign"}</span></div>
+        <div className="play-toolbar-actions">
+          {mode === "table" ? <><button type="button" className="ghost-button" onClick={() => setShowHud((value) => !value)}>{showHud ? "Hide HUD" : "Show HUD"}</button>{showHud ? <button type="button" className="ghost-button" onClick={() => setResetToken((value) => value + 1)}>Reset HUD</button> : null}</> : <>
+            <div className="companion-source-switch" role="group" aria-label="Companion data source">
+              <button type="button" className={effectiveSource === "campaign" ? "active" : ""} disabled={!campaignState} onClick={() => setCompanionSource("campaign")}>Campaign</button>
+              <button type="button" className={effectiveSource === "offline" ? "active" : ""} onClick={() => setCompanionSource("offline")}>Offline local</button>
+            </div>
+            {effectiveSource === "offline" && campaignState ? <button type="button" className="ghost-button" onClick={() => offline.adoptCampaign(campaignState)}>Copy campaign state</button> : null}
+            <button type="button" className="ghost-button" onClick={() => setResetToken((value) => value + 1)}>Reset HUD</button>
+          </>}
+        </div>
+      </header>
+
+      {connectionError && !campaignState ? <div className="play-connection-note"><span>{connectionError}</span><button type="button" onClick={onReconnect}>Retry campaign</button></div> : null}
+
+      {mode === "table" ? (
+        campaignState ? <VirtualTable state={campaignState} clientName={clientName} onRoll={onRoll} onAdjustHp={onAdjustHp} onMoveToken={onMoveToken} showHud={showHud} resetToken={resetToken} /> : <section className="play-unavailable"><div className="sigil">UTT</div><h1>Virtual Table needs a live campaign</h1><p>Companion can keep running from local state while the campaign is unavailable.</p><button type="button" className="game-button primary" onClick={() => setMode("companion")}>Open Companion</button></section>
+      ) : (
+        <HudGrid
+          state={companionState}
+          onRoll={effectiveSource === "campaign" ? onRoll : offline.roll}
+          onAdjustHp={effectiveSource === "campaign" ? onAdjustHp : offline.adjustHp}
+          layoutResetToken={resetToken}
+          authority={effectiveSource}
+        />
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/components/SceneCanvas.tsx
+++ b/apps/web/src/components/SceneCanvas.tsx
@@ -10,15 +10,16 @@ interface SceneCanvasProps {
   clientName: string;
   selectedHotspotId: string | null;
   selectedHotspotLore: string | null;
-  selectedHotspotLinkedSceneName: string | null;
-  addPinMode: boolean;
-  addTokenMode: boolean;
-  onToggleAddPin: () => void;
-  onToggleAddToken: () => void;
-  onCanvasPoint: (point: { x: number; y: number }) => void;
-  onTokenPoint: (point: { x: number; y: number }) => void;
-  onHotspotSelect: (hotspot: AtlasHotspotDto) => void;
-  onHotspotEnter: (hotspot: AtlasHotspotDto) => void;
+  selectedHotspotLinkedSceneName?: string | null;
+  mode?: "director" | "play";
+  addPinMode?: boolean;
+  addTokenMode?: boolean;
+  onToggleAddPin?: () => void;
+  onToggleAddToken?: () => void;
+  onCanvasPoint?: (point: { x: number; y: number }) => void;
+  onTokenPoint?: (point: { x: number; y: number }) => void;
+  onHotspotSelect?: (hotspot: AtlasHotspotDto) => void;
+  onHotspotEnter?: (hotspot: AtlasHotspotDto) => void;
   onTokenMove: (tokenId: string, x: number, y: number) => void;
 }
 
@@ -52,7 +53,7 @@ function GridOverlay({ scene }: { scene: AtlasSceneDto }) {
 
 export function SceneCanvas({
   scene, hotspots, tokens, clientName, selectedHotspotId, selectedHotspotLore, selectedHotspotLinkedSceneName,
-  addPinMode, addTokenMode, onToggleAddPin, onToggleAddToken, onCanvasPoint, onTokenPoint, onHotspotSelect, onHotspotEnter, onTokenMove
+  mode = "director", addPinMode = false, addTokenMode = false, onToggleAddPin, onToggleAddToken, onCanvasPoint, onTokenPoint, onHotspotSelect, onHotspotEnter, onTokenMove
 }: SceneCanvasProps) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<{ pointerId: number; x: number; y: number; cameraX: number; cameraY: number } | null>(null);
@@ -99,15 +100,15 @@ export function SceneCanvas({
   const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
     const rect = event.currentTarget.getBoundingClientRect();
-    if (addPinMode || addTokenMode) {
+    if (mode === "director" && (addPinMode || addTokenMode)) {
       const worldX = (event.clientX - rect.left - camera.x) / camera.scale;
       const worldY = (event.clientY - rect.top - camera.y) / camera.scale;
       const point = {
         x: clamp(worldX / scene.backgroundWidth, 0, 1),
         y: clamp(worldY / scene.backgroundHeight, 0, 1)
       };
-      if (addTokenMode) onTokenPoint(point);
-      else onCanvasPoint(point);
+      if (addTokenMode) onTokenPoint?.(point);
+      else onCanvasPoint?.(point);
       return;
     }
     dragRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY, cameraX: camera.x, cameraY: camera.y };
@@ -168,12 +169,14 @@ export function SceneCanvas({
   };
 
   return (
-    <section className={`scene-viewport ${addPinMode ? "placing-pin" : ""} ${addTokenMode ? "placing-token" : ""}`} ref={viewportRef} onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={stopDrag} onPointerCancel={stopDrag}>
+    <section className={`scene-viewport ${mode === "play" ? "play-scene" : ""} ${addPinMode ? "placing-pin" : ""} ${addTokenMode ? "placing-token" : ""}`} ref={viewportRef} onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={stopDrag} onPointerCancel={stopDrag}>
       <div className="scene-toolbar" onPointerDown={(event) => event.stopPropagation()}>
         <button type="button" className="map-tool" onClick={fit}>Fit</button>
         <span>{Math.round(camera.scale * 100)}%</span>
-        <button type="button" className={`map-tool ${addPinMode ? "active" : ""}`} onClick={onToggleAddPin}>{addPinMode ? "Cancel pin" : "+ Pin"}</button>
-        <button type="button" className={`map-tool ${addTokenMode ? "active" : ""}`} onClick={onToggleAddToken}>{addTokenMode ? "Cancel token" : "+ Token"}</button>
+        {mode === "director" ? <>
+          <button type="button" className={`map-tool ${addPinMode ? "active" : ""}`} onClick={onToggleAddPin}>{addPinMode ? "Cancel pin" : "+ Pin"}</button>
+          <button type="button" className={`map-tool ${addTokenMode ? "active" : ""}`} onClick={onToggleAddToken}>{addTokenMode ? "Cancel token" : "+ Token"}</button>
+        </> : null}
       </div>
       {addPinMode ? <div className="placement-hint">Click anywhere on the scene to place a hotspot</div> : null}
       {addTokenMode ? <div className="placement-hint">Click anywhere on the scene to place a token</div> : null}
@@ -216,8 +219,8 @@ export function SceneCanvas({
                   type="button"
                   className={`scene-hotspot ${selected ? "selected" : ""}`}
                   aria-label={`Open ${hotspot.label} hotspot`}
-                  onClick={(event) => { event.stopPropagation(); onHotspotSelect(hotspot); }}
-                  onDoubleClick={(event) => { event.stopPropagation(); if (hotspot.linkedSceneId) onHotspotEnter(hotspot); }}
+                  onClick={(event) => { event.stopPropagation(); onHotspotSelect?.(hotspot); }}
+                  onDoubleClick={(event) => { event.stopPropagation(); if (hotspot.linkedSceneId) onHotspotEnter?.(hotspot); }}
                 >
                   <span className="hotspot-dot"><i>◆</i></span><span className="hotspot-label">{hotspot.label}</span>
                 </button>
@@ -225,7 +228,7 @@ export function SceneCanvas({
                   <div className="hotspot-popover">
                     <strong>{hotspot.label}</strong>
                     <p>{selectedHotspotLore || "No lore summary attached yet."}</p>
-                    {hotspot.linkedSceneId ? <button type="button" className="game-button primary" onClick={() => onHotspotEnter(hotspot)}>Open {selectedHotspotLinkedSceneName || "linked scene"}</button> : null}
+                    {hotspot.linkedSceneId && onHotspotEnter ? <button type="button" className="game-button primary" onClick={() => onHotspotEnter(hotspot)}>Open {selectedHotspotLinkedSceneName || "linked scene"}</button> : null}
                   </div>
                 ) : null}
               </div>

--- a/apps/web/src/components/SessionHudWidgets.tsx
+++ b/apps/web/src/components/SessionHudWidgets.tsx
@@ -1,0 +1,49 @@
+import { useMemo, useState, type ReactNode } from "react";
+import type { LiveViewState } from "../live-room.js";
+import { WidgetFrame } from "./WidgetFrame.js";
+
+export interface SessionHudOptions {
+  state: LiveViewState;
+  onRoll: (sides: number, modifier: number) => void;
+  onAdjustHp: (delta: number) => void;
+  authority: "campaign" | "offline";
+}
+
+export function useSessionHudWidgets({ state, onRoll, onAdjustHp, authority }: SessionHudOptions): Record<string, ReactNode> {
+  const [die, setDie] = useState(20);
+  const [modifier, setModifier] = useState(5);
+  const hpPercent = Math.round((state.hp / state.maxHp) * 100);
+  const authorityNote = authority === "campaign"
+    ? "Campaign authoritative. Accepted changes become durable session events."
+    : "Offline local state. Changes stay on this device and do not sync automatically.";
+  const rngMeta = authority === "campaign" ? "Server RNG" : "Local RNG";
+
+  return useMemo(() => ({
+    character: (
+      <WidgetFrame eyebrow="Character" title={state.characterName} meta={`#${state.sessionId.slice(-3)}`}>
+        <div className="vital-row"><div><span className="vital-label">Hit points</span><strong className="hp-value">{state.hp}<small> / {state.maxHp}</small></strong></div><span className="hp-percent">{hpPercent}%</span></div>
+        <div className="hp-track"><span style={{ width: `${hpPercent}%` }} /></div>
+        <div className="action-cluster" aria-label="Adjust hit points">
+          {[-5, -1, 1, 5].map((delta) => <button className="game-button compact" type="button" key={delta} onClick={() => onAdjustHp(delta)}>{delta > 0 ? `+${delta}` : delta}</button>)}
+        </div>
+        <p className="widget-note">{authorityNote}</p>
+      </WidgetFrame>
+    ),
+    dice: (
+      <WidgetFrame eyebrow="Action" title="Dice rig" meta={rngMeta}>
+        <div className="die-row">{[4, 6, 8, 10, 12, 20, 100].map((sides) => <button className={`die-chip ${die === sides ? "active" : ""}`} type="button" key={sides} onClick={() => setDie(sides)}>d{sides}</button>)}</div>
+        <label className="modifier-control"><span>Modifier</span><input type="number" min={-20} max={20} value={modifier} onChange={(event) => setModifier(Number(event.target.value))} /></label>
+        <button className="game-button primary roll-button" type="button" onClick={() => onRoll(die, modifier)}>Roll d{die} {modifier >= 0 ? `+${modifier}` : modifier}</button>
+        <div className="roll-result" aria-live="polite">{state.latestRoll ? <><span>Latest</span><strong>{state.latestRoll.total}</strong><small>d{state.latestRoll.sides}: {state.latestRoll.natural} {state.latestRoll.modifier >= 0 ? "+" : ""}{state.latestRoll.modifier}</small></> : <p>No roll yet. Make the first move.</p>}</div>
+      </WidgetFrame>
+    ),
+    events: (
+      <WidgetFrame eyebrow={authority === "campaign" ? "Live feed" : "Local feed"} title="Table log" meta={`${state.eventSequence} events`}>
+        <div className="event-list" role="log" aria-live="polite">
+          {[...state.events].reverse().map((event) => <article className="event-row" key={event.sequence}><span className={`event-icon ${event.kind}`}>{event.kind === "roll" ? "◆" : event.kind === "hp" ? "♥" : "↪"}</span><div><p>{event.summary}</p><small>#{event.sequence} · {new Date(event.at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}</small></div></article>)}
+          {state.events.length === 0 ? <p className="empty-state">The table is quiet. Roll or change HP to create the first event.</p> : null}
+        </div>
+      </WidgetFrame>
+    )
+  }), [authority, authorityNote, die, hpPercent, modifier, onAdjustHp, onRoll, rngMeta, state]);
+}

--- a/apps/web/src/offline-companion.ts
+++ b/apps/web/src/offline-companion.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useState } from "react";
+import type { LiveViewState } from "./live-room.js";
+
+const STORAGE_KEY = "utt.offline.companion.v1";
+const MAX_EVENTS = 50;
+
+function localRandomInt(maxExclusive: number): number {
+  if (!Number.isInteger(maxExclusive) || maxExclusive <= 0) throw new Error("Invalid local die size");
+  if (!globalThis.crypto?.getRandomValues) return Math.floor(Math.random() * maxExclusive);
+  const range = 0x1_0000_0000;
+  const limit = range - (range % maxExclusive);
+  const buffer = new Uint32Array(1);
+  do globalThis.crypto.getRandomValues(buffer); while ((buffer[0] ?? 0) >= limit);
+  return (buffer[0] ?? 0) % maxExclusive;
+}
+
+function offlineState(seed: LiveViewState | null, copied = false): LiveViewState {
+  const now = new Date().toISOString();
+  return {
+    sessionId: seed ? `offline-${seed.sessionId}` : "offline-local",
+    characterName: seed?.characterName ?? "Offline Adventurer",
+    hp: seed?.hp ?? 10,
+    maxHp: seed?.maxHp ?? 10,
+    connectedPlayers: 1,
+    eventSequence: copied ? 1 : 0,
+    activeSceneId: "",
+    tokens: [],
+    latestRoll: null,
+    events: copied ? [{ sequence: 1, kind: "offline", actor: "Local", summary: "Copied current campaign character state for offline play", at: now }] : []
+  };
+}
+
+function loadOffline(seed: LiveViewState | null): LiveViewState {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return offlineState(seed);
+    const parsed = JSON.parse(raw) as LiveViewState;
+    if (typeof parsed.characterName !== "string" || !Number.isFinite(parsed.hp) || !Number.isFinite(parsed.maxHp) || !Array.isArray(parsed.events)) return offlineState(seed);
+    return { ...parsed, connectedPlayers: 1, activeSceneId: "", tokens: [] };
+  } catch {
+    return offlineState(seed);
+  }
+}
+
+export function useOfflineCompanion(seed: LiveViewState | null) {
+  const [state, setState] = useState<LiveViewState>(() => loadOffline(seed));
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }, [state]);
+
+  const appendEvent = useCallback((kind: string, summary: string, mutate: (current: LiveViewState) => Partial<LiveViewState>) => {
+    setState((current) => {
+      const sequence = current.eventSequence + 1;
+      const event = { sequence, kind, actor: "Local", summary, at: new Date().toISOString() };
+      return { ...current, ...mutate(current), eventSequence: sequence, events: [...current.events, event].slice(-MAX_EVENTS) };
+    });
+  }, []);
+
+  const adjustHp = useCallback((delta: number) => {
+    if (!Number.isFinite(delta)) return;
+    appendEvent("hp", `${delta >= 0 ? "+" : ""}${delta} HP (offline)`, (current) => ({ hp: Math.max(0, Math.min(current.maxHp, current.hp + delta)) }));
+  }, [appendEvent]);
+
+  const roll = useCallback((sides: number, modifier: number) => {
+    const natural = localRandomInt(sides) + 1;
+    const total = natural + modifier;
+    appendEvent("roll", `Rolled d${sides} ${modifier >= 0 ? "+" : ""}${modifier}: ${total} (offline)`, () => ({ latestRoll: { sides, natural, modifier, total } }));
+  }, [appendEvent]);
+
+  const adoptCampaign = useCallback((campaign: LiveViewState) => setState(offlineState(campaign, true)), []);
+
+  return { state, adjustHp, roll, adoptCampaign };
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -365,3 +365,62 @@ button { color: inherit; }
   .freeform-surface:not(.overlay) { min-width: 980px; min-height: 680px; }
   .director-freeform { display: none; }
 }
+
+/* VS003.6 — unified Play surface */
+.play-workspace { flex: 1; min-height: 0; display: flex; flex-direction: column; background: #07090d; }
+.play-toolbar {
+  position: relative; z-index: 45; min-height: 54px; display: grid; grid-template-columns: minmax(210px,1fr) auto minmax(210px,1fr);
+  align-items: center; gap: 12px; padding: 8px 14px; border-bottom: 1px solid rgba(255,255,255,.06); background: rgba(10,12,17,.96);
+}
+.play-mode-switch, .companion-source-switch { display: flex; width: max-content; gap: 3px; padding: 3px; border: 1px solid rgba(255,255,255,.08); border-radius: 9px; background: rgba(255,255,255,.025); }
+.play-mode-switch button, .companion-source-switch button { border: 0; border-radius: 6px; padding: 6px 10px; background: transparent; color: var(--muted); cursor: pointer; font-size: 10px; }
+.play-mode-switch button.active, .companion-source-switch button.active { color: #f0dfc4; background: rgba(197,156,91,.14); }
+.play-mode-switch button:disabled, .companion-source-switch button:disabled { opacity: .35; cursor: not-allowed; }
+.play-toolbar-status { display: flex; align-items: center; justify-content: center; gap: 8px; color: #9198a4; font-size: 10px; }
+.play-toolbar-actions { display: flex; align-items: center; justify-content: flex-end; gap: 7px; min-width: 0; }
+.play-toolbar-actions .ghost-button { padding: 6px 9px; font-size: 10px; }
+.play-connection-note { display: flex; align-items: center; justify-content: center; gap: 10px; padding: 6px 12px; border-bottom: 1px solid rgba(217,97,97,.18); background: rgba(217,97,97,.06); color: #ca9191; font-size: 10px; }
+.play-connection-note button { border: 0; background: transparent; color: #efb4b4; cursor: pointer; text-decoration: underline; }
+.play-table-stage { position: relative; flex: 1; min-height: 0; display: flex; overflow: hidden; background: #06080b; }
+.play-table-stage > .scene-viewport { flex: 1; min-height: 0; }
+.play-scene-title { position: absolute; z-index: 23; top: 12px; left: 50%; transform: translateX(-50%); display: flex; flex-direction: column; align-items: center; gap: 1px; padding: 6px 10px; border: 1px solid rgba(255,255,255,.08); border-radius: 8px; background: rgba(7,9,13,.8); backdrop-filter: blur(10px); pointer-events: none; }
+.play-scene-title span { color: #777f8b; font-size: 8px; letter-spacing: .11em; text-transform: uppercase; }
+.play-scene-title strong { max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #e6dfd4; font: 500 13px Georgia, serif; }
+.play-hud-freeform { z-index: 25 !important; }
+.play-hud-freeform .hud-widget { background: linear-gradient(165deg, rgba(20,24,32,.90), rgba(10,12,17,.86)); backdrop-filter: blur(10px); }
+.play-hud-freeform .widget-handle { min-height: 52px; padding: 8px 11px; }
+.play-hud-freeform .widget-handle h2 { font-size: 15px; }
+.play-hud-freeform .widget-body { padding: 11px; gap: 10px; }
+.play-mobile-hud { display: none; }
+.play-table-loading, .play-unavailable { flex: 1; display: grid; place-content: center; gap: 8px; padding: 28px; text-align: center; color: var(--muted); }
+.play-table-loading strong, .play-unavailable h1 { margin: 0; color: #dfd9cf; font: 500 22px Georgia, serif; }
+.play-table-loading span, .play-unavailable p { margin: 0; font-size: 11px; }
+.play-unavailable .sigil { margin: 0 auto 8px; width: 58px; height: 58px; display: grid; place-items: center; border: 1px solid rgba(197,156,91,.35); border-radius: 18px; color: var(--bronze-soft); font-family: Georgia, serif; }
+.play-unavailable .game-button { margin: 8px auto 0; min-width: 150px; padding: 9px 12px; }
+
+@media (max-width: 980px) {
+  .play-toolbar { grid-template-columns: auto 1fr; }
+  .play-toolbar-status { justify-content: flex-end; }
+  .play-toolbar-actions { grid-column: 1 / -1; justify-content: flex-start; overflow-x: auto; padding-bottom: 1px; }
+}
+
+@media (max-width: 720px) {
+  .play-toolbar { grid-template-columns: 1fr auto; min-height: 50px; padding: 6px 8px; gap: 7px; }
+  .play-mode-switch button { padding: 6px 8px; }
+  .play-toolbar-status { font-size: 9px; }
+  .play-toolbar-actions { grid-column: 1 / -1; gap: 5px; }
+  .companion-source-switch button { padding: 5px 7px; font-size: 9px; }
+  .play-table-stage { min-height: 520px; }
+  .play-scene-title { top: 48px; max-width: 62vw; }
+  .play-hud-freeform { display: none; }
+  .play-mobile-hud { position: absolute; z-index: 32; inset: auto 8px 8px; display: flex; flex-direction: column; gap: 6px; pointer-events: none; }
+  .play-mobile-widget { max-height: 42vh; pointer-events: auto; overflow: hidden; }
+  .play-mobile-widget > .hud-widget { max-height: 42vh; border-radius: 12px; background: linear-gradient(165deg, rgba(20,24,32,.95), rgba(10,12,17,.94)); backdrop-filter: blur(12px); }
+  .play-mobile-widget .widget-handle { min-height: 48px; padding: 7px 10px; cursor: default; }
+  .play-mobile-widget .widget-handle h2 { font-size: 15px; }
+  .play-mobile-widget .widget-body { padding: 10px; gap: 9px; }
+  .play-mobile-dock { align-self: center; display: flex; gap: 3px; padding: 3px; border: 1px solid rgba(255,255,255,.10); border-radius: 10px; background: rgba(8,10,14,.94); backdrop-filter: blur(12px); pointer-events: auto; }
+  .play-mobile-dock button { border: 0; border-radius: 7px; padding: 7px 11px; background: transparent; color: #8d949f; font-size: 10px; }
+  .play-mobile-dock button.active { color: #f2e4cb; background: rgba(197,156,91,.16); }
+  .play-workspace .hud-stage.freeform-mode { overflow-x: auto; }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,11 +1,11 @@
 # Architecture
 
-Status: **foundation + Vertical Slice 003.5 table UX stabilization**
+Status: **foundation + Vertical Slice 003.6 unified Play surface**
 
 ## Boundary model
 
 ```text
-React UI / freeform DOM workspaces + Scene Atlas
+React UI / Director + unified Play surfaces + Scene Atlas
         |                \
         | live intents    \ durable world edits / assets
         v                  v
@@ -36,6 +36,8 @@ The room contains the VS001 character/roll/HP state, `activeSceneId`, and a sync
 
 Director browsing is intentionally **not** authoritative. A client can pan, zoom, select hotspots and browse another scene without moving the table. Clients that follow the table react to `activeSceneId`; if that scene was created after their Atlas snapshot, they refresh durable Atlas data before navigating.
 
+Play is a projection over session state. Virtual Table resolves `activeSceneId` to the durable scene record and renders scene + active token projection underneath a local freeform HUD. Companion renders the same session widgets without a map. Campaign Companion sends intents to Colyseus; Offline Companion instead mutates browser-local HP/dice/log state and never auto-merges it back into campaign state.
+
 ## Current durable world model
 
 VS002/VS003 currently use four small `SCHEMAFULL` world tables:
@@ -55,7 +57,7 @@ The model deliberately permits partial entities. A scene may exist without lore;
 
 **Durable asset state:** uploaded PNG/JPEG/WebP bytes in the private `scene-assets` Docker volume. SurrealDB stores only generated asset keys and image dimensions.
 
-**Presentation state:** pan/zoom, current private browse scene, selected hotspot, freeform widget placements/z-order and optional snap-grid layout. These are not game truth. Live and Director use the same role-neutral freeform primitive with different widget content.
+**Presentation/local-only state:** pan/zoom, Play/Companion mode, current private browse scene, selected hotspot, freeform widget placements/z-order, optional snap-grid layout, and explicit Offline Companion HP/dice/log state. These are not authoritative campaign truth. Play and Director use the same role-neutral freeform primitive with different widget content.
 
 ## Not implemented yet
 

--- a/docs/SCENE-ATLAS-DIRECTION.md
+++ b/docs/SCENE-ATLAS-DIRECTION.md
@@ -48,9 +48,9 @@ The product must not force a user to build a map inside UTT before they can play
 
 ## Relationship to Live
 
-The same scene model can back world navigation and live play. A DM can activate a scene for the table; clients transition to that scene while server-side visibility determines what each participant receives.
+The same scene model can back world navigation and virtual-table play. A DM can activate a scene for the table; Virtual Table clients transition to that scene while server-side visibility will eventually determine what each participant receives. Companion clients may participate in the same session without rendering a scene at all.
 
-Scene switching should therefore be an authoritative live-session operation, while zoom, local HUD layout and similar presentation preferences remain client state.
+Scene switching should therefore be an authoritative live-session operation, while the choice of Play surface, zoom, local HUD layout and similar presentation preferences remain client state.
 
 ## Proven primitive
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -12,6 +12,7 @@ Compensating development controls:
 - the database uses a `STRICT` scope and VS001/VS002/VS003 application tables are `SCHEMAFULL`;
 - containers that write durable data run non-root after one-shot volume ownership initialization;
 - no production/user data is used in this environment.
+- Offline Companion state (current HP, local dice result and local event log) is stored in browser `localStorage`; it is neither encrypted nor synchronized and must not be used for secrets or treated as campaign-authoritative storage.
 
 ## Known security limitation
 

--- a/docs/VERTICAL-SLICE-003-6.md
+++ b/docs/VERTICAL-SLICE-003-6.md
@@ -1,0 +1,38 @@
+# Vertical Slice 003.6 — Unified Play surface
+
+Status: **complete / proven on homelab — 2026-08-16**.
+
+## Problem
+Before this slice, `Live` rendered only the freeform HUD. The active scene, map and synchronized tokens were visible only in Director. That contradicted the session-first VTT direction while the existing HUD remained valuable for physical-table play.
+
+## Implemented behavior
+- top-level workspace is now `Director | Play`;
+- Play defaults to `Virtual Table` for a connected campaign;
+- Virtual Table renders the authoritative `activeSceneId`, scene background/grid and live token projection as the base layer;
+- Character, Dice and Table Log reuse one widget implementation and float above the scene through `FreeformSurface`;
+- Virtual Table does not expose Director `+ Pin` / `+ Token` authoring controls;
+- HUD can be hidden or reset without affecting map/session truth;
+- Companion preserves the map-free HUD for physical-table use;
+- Companion can use Campaign-authoritative state or explicit Offline local state;
+- Offline local supports persistent HP, local dice and a local event log;
+- copying current campaign character state into Offline is explicit;
+- reconnect never silently replaces Offline with Campaign;
+- mobile Virtual Table keeps the map visible and presents one Character/Dice/Log drawer at a time.
+
+## Executable evidence
+Baseline on `main` reproduced the original problem with `sceneViewport=0`, `tokenCount=0`, `hudStage=1` in Live.
+
+After implementation, browser QA on the Tailscale preview observed `sceneViewport=1`, active scene `Copper Road Ambush`, synchronized tokens and three HUD widgets mounted on the same Virtual Table surface. No Director placement controls were present.
+
+Two independent browser contexts moved `Mira Voss`: the peer converged from approximately `(638.2, 448.3)` to `(710.1, 484.2)`, successful-move post-release excursion remained `0 px`, and the token was restored to its original visual position. No console errors were recorded.
+
+With the game-server fully stopped, Offline Companion changed HP `10 -> 9`, rolled locally, and retained both HP and roll after a static-page reload. Campaign controls were disabled. A separate reconnect test proved that Offline remained selected after the game-server returned and `Retry campaign` succeeded; Campaign became available but was not chosen automatically.
+
+Desktop 1440×900 and mobile 390×844 screenshots were visually inspected. Mobile uses a compact bottom drawer so the map remains the primary surface.
+
+Full workspace gate passed: strict typecheck, ESLint, 14 domain tests, 4 game-server tests, and production builds.
+
+## Boundaries / non-goals
+`Offline local` does **not** mean the application shell is installable or bootable with no web server; PWA/service-worker caching is future work. Offline changes are not synchronized or conflict-merged into a campaign. Auth/roles, player-specific scene filtering, walls, doors, vision/fog, initiative/targeting and full Character/Action/Effect engines remain separate milestones.
+
+An abrupt loss of an already-open Colyseus WebSocket was not observed to flip the UI to `disconnected` within a 15-second QA window; startup with the campaign runtime unavailable and explicit retry/reconnect are proven. Connection liveness/heartbeat UX remains a future reliability concern rather than being hidden by this slice.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -12,9 +12,11 @@ The defining experience is the live session. A player or DM should feel that the
 
 ## Live experience
 
-The HUD is modular. Containers can be dragged, resized, hidden and configured. Examples include character status, HP/resources, actions, spells, inventory, dice, conditions, initiative, selected target, event log, notes and future playfield/map surfaces.
+Play is participation in the session, not one mandatory screen. A virtual-table surface should use the active map/scene and tokens as the playfield with modular HUD windows above it. A physical-table Companion surface should keep the same character/dice/action tools useful without requiring a digital map. Mixed tables may use both projections at once.
 
-Layouts are presentation state. They must not become authoritative game state.
+The HUD is modular. Containers can be dragged, resized, hidden and configured. Examples include character status, HP/resources, actions, spells, inventory, dice, conditions, initiative, selected target, event log and notes. Layouts are presentation state and must not become authoritative game state.
+
+Local/offline companion play is a valid mode, but local changes must not be silently presented as campaign truth or merged without an explicit synchronization/conflict policy.
 
 ## Homebrew is not a special case
 

--- a/docs/adr/0015-unified-play-surface.md
+++ b/docs/adr/0015-unified-play-surface.md
@@ -1,0 +1,24 @@
+# ADR 0015 — Unified Play surfaces
+
+Status: Accepted
+
+## Context
+VS003.5 exposed a customizable Live HUD, while the actual scene/map and synchronized tokens remained in Director/Atlas. That split made the primary live experience unsuitable for virtual tabletop play, but replacing the HUD with a mandatory map would make UTT worse as a companion for groups playing physically.
+
+## Decision
+Treat **Play** as participation in a session, not as a specific renderer. Play currently offers two presentation surfaces over the same product model:
+
+- **Virtual Table** — the authoritative active scene and synchronized tokens are the base surface; the freeform session HUD floats above it.
+- **Companion** — the session HUD is the primary surface and no map is required, supporting physical-table use.
+
+Connected Companion uses the same Colyseus-authoritative campaign state as Virtual Table. Companion may instead use explicit **Offline local** state for HP, dice and its local event log. Offline state is browser-local presentation/session aid state and is never silently merged into campaign state. If campaign connectivity is unavailable, the source becomes Offline and remains Offline after reconnect until the user explicitly chooses Campaign.
+
+Director remains the preparation/authoring projection and may browse privately away from the active scene.
+
+## Consequences
+- maps are optional participation surfaces rather than the definition of a live session;
+- virtual, physical and mixed-device tables can share one session model;
+- DM/player widget catalogs can keep using the same freeform primitive;
+- offline local changes are intentionally isolated and require a future explicit merge/conflict design before campaign synchronization;
+- service-worker/PWA offline boot is not implied by this decision;
+- walls, vision and fog can now target the Virtual Table scene layer without affecting Companion.


### PR DESCRIPTION
## Summary

Unifies UTT's live play experience without sacrificing the physical-table companion workflow.

### Play surfaces
- Top-level product split is now **Director | Play**.
- **Virtual Table** renders the authoritative active scene, map/grid and synchronized tokens as the base surface, with Character/Dice/Log freeform widgets floating above it.
- Virtual Table intentionally omits Director authoring controls (`+ Pin`, `+ Token`).
- **Companion** preserves the map-free HUD for physical-table play and can use campaign-authoritative state or explicit browser-local offline state.
- Mobile Virtual Table keeps the map visible and exposes Character/Dice/Log through a compact bottom drawer.

### Offline boundary
- Offline local HP, dice and local event log persist in `localStorage`.
- Copying campaign character state into Offline is explicit.
- Offline changes never auto-merge into campaign state.
- A reconnect makes Campaign available again but does not silently switch away from Offline.
- This does not claim PWA/service-worker offline boot.

### Verification
- Remote Git tree exactly matches the locally verified commit tree: `097d0c0a113fd6dba83cd4ca08bc6e1cef782dd3`.
- Full `pnpm check` green after final startup-race fix: strict typecheck, ESLint, 14/14 domain tests, 4/4 game-server tests, production builds.
- Actual Tailscale browser smoke: `Copper Road Ambush`, scene viewport present, synchronized tokens present, 3 HUD widgets, no Director placement controls, zero console/page errors on desktop and 390×844 mobile.
- Two independent browser contexts synchronized a Mira Voss token move; successful-move post-release excursion stayed `0 px`, then the token was restored.
- With game-server stopped before page load, Offline Companion changed HP `10→9`, rolled locally and retained both after reload; Campaign was disabled.
- Online startup race was independently caught and fixed: Campaign Companion now remains on authoritative `32/32` during the connection handshake instead of prematurely falling back to Offline.

### Known boundary
An already-open Colyseus socket did not surface abrupt server death as `disconnected` within a 15-second QA window. Startup-unavailable and explicit retry/reconnect behavior are proven; heartbeat/liveness UX remains future reliability work.

No backend protocol, database schema, auth policy, dependency or public exposure changes are included.